### PR TITLE
PreFlight Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 'use strict';
 
+var pluginErrors = require('./lib/errors');
+var spawnSync = require('child_process').spawnSync;
+
+var preFlightCheck = spawnSync('ffmpeg', ['-version']).error === undefined;
+
 function AudioSpritePlugin (options) {}
 
 AudioSpritePlugin.loader = function(options) {
@@ -13,6 +18,11 @@ AudioSpritePlugin.prototype.loader = function(options) {
 };
 
 AudioSpritePlugin.prototype.apply = function(compiler) {
+	compiler.plugin('compilation', function(compilation) {
+		if (!preFlightCheck) {
+			compilation.errors.push(pluginErrors.preflightError);
+		}
+	});
 
 };
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var pluginName = 'webpack-audio-sprite-loader';
+
+function format(errMsg) {
+	return pluginName + ': ' + errMsg;
+}
+
+module.exports = {
+	preflightError: format('ffprobe and ffmpeg must be locally installed.' +
+		' @see: https://www.ffmpeg.org')
+};

--- a/loader.js
+++ b/loader.js
@@ -1,5 +1,13 @@
 'use strict';
 
+var pluginErrors = require('./lib/errors');
+var spawnSync = require('child_process').spawnSync;
+
+var preFlightCheck = spawnSync('ffprobe', ['-version']).error === undefined;
+
 module.exports = function(source) {
+	if (!preFlightCheck) {
+		throw new Error(pluginErrors.preflightError);
+	}
 	return 'module.exports = {};';
 };


### PR DESCRIPTION
Do preflight checks in plugin and loader, emit errors when failed.
## Output Examples:

**Plugin:**

```
Hash: 2756dff0eedd62bc7223
Version: webpack 1.13.0
Time: 83ms
  Asset    Size  Chunks             Chunk Names
main.js  1.8 kB       0  [emitted]  main
   [0] ./index.js 189 bytes {0} [built]
   [1] ./assets/thud.mp3 20 bytes {0} [not cacheable] [built]
   [2] ./assets/quack.mp3 20 bytes {0} [not cacheable] [built]
   [3] ./assets/loserSound.mp3 20 bytes {0} [not cacheable] [built]

ERROR in webpack-audio-sprite-loader: ffprobe and ffmpeg must be locally installed. @see: https://www.ffmpeg.org
```

**Loader:**

```
Hash: 3ba7d08d8e24fe89476c
Version: webpack 1.13.0
Time: 64ms
  Asset  Size  Chunks             Chunk Names
main.js  2 kB       0  [emitted]  main
   [0] ./index.js 189 bytes {0} [built] [3 errors]
   [1] ./assets/thud.mp3 0 bytes [not cacheable] [built] [failed]
   [2] ./assets/quack.mp3 0 bytes [not cacheable] [built] [failed]
   [3] ./assets/loserSound.mp3 0 bytes [not cacheable] [built] [failed]

ERROR in ./assets/thud.mp3
Module build failed: Error: webpack-audio-sprite-loader: ffprobe and ffmpeg must be locally installed. @see: https://www.ffmpeg.org
    at Object.module.exports (/home/matt/Code/webpack-audio-sprite-plugin/loader.js:10:9)
 @ ./index.js 3:11-39

ERROR in ./assets/quack.mp3
Module build failed: Error: webpack-audio-sprite-loader: ffprobe and ffmpeg must be locally installed. @see: https://www.ffmpeg.org
    at Object.module.exports (/home/matt/Code/webpack-audio-sprite-plugin/loader.js:10:9)
 @ ./index.js 4:12-41

ERROR in ./assets/loserSound.mp3
Module build failed: Error: webpack-audio-sprite-loader: ffprobe and ffmpeg must be locally installed. @see: https://www.ffmpeg.org
    at Object.module.exports (/home/matt/Code/webpack-audio-sprite-plugin/loader.js:10:9)
 @ ./index.js 5:17-51

```
